### PR TITLE
Various changes to lua.md

### DIFF
--- a/why/lua.md
+++ b/why/lua.md
@@ -2,8 +2,11 @@
 title: Lua
 layout: language
 date: 2017
-author: theory.org
+authors: theory.org and big-lip-bob
 ---
+
+# Syntax
+
 * Variable declaration is global by default, and looks exactly like assignment.
 
 ```lua
@@ -15,6 +18,28 @@ print(realVar, real_var) -- nil, "bar"
 ```
 
 * A dereference on a non-existing key returns `nil` instead of an error. This, coupled with the above point makes misspellings hazardous, and mostly silent, in Lua.
+It is possible to overload deferencing of non-existing keys and the declaration of new global variables by adding metamethods,
+and the Global variables are part of the Global table `_G` which can have its operators overloaded too.
+
+```lua
+setmetatable(_G,{
+  __newindex = function(self,key,value) error("tried to add a new global : "..key.." = "..value) end,
+  __index = function(self,key) error("Tried to acces non existing global : "..key) end
+})
+a = 5 -- error, new global added
+print(b) -- error, empty global read
+```
+
+* `break`, `do while` (`while something do` and  `repeat something until something`), and `goto` exist, but not `continue`. Bizzare.
+* Statements are distinct from expressions, and expressions cannot exist outside of statements:
+
+```lua
+do 2+2 end -- unexpected symbol near '2'
+do return 2+2 end -- 4
+```
+
+# Types
+
 * If a vararg is in the middle of a list of arguments only the first argument gets counted.
 
 ```lua
@@ -23,23 +48,19 @@ print("foo", fn()) -- foo bar baz
 print("foo", fn(), "qux") -- foo bar qux
 ```
 
-* you can hold only one vararg at a time(in `...`)
-* You can't store varargs for later.
-* You can't iterate over varargs.
+* You can hold only one vararg at a time (in `...`) 
 * You can't mutate varargs directly.
-* You can pack varargs into tables to do these things, but then you have to worry about escaping the nil values,
-which are valid in varargs but signal the end of tables, like `\0` in C strings.
-* Table indexes start at one in array literals, and in the standard library.
-You can use 0-based indexing, but then you can't use either of those things.
-* `break`, `do while` (`while (something) do` and  `repeat something until something`), and `goto` exist, but not `continue`. Bizzare.
-* Statements are distinct from expressions, and expressions cannot exist outside of statements:
+* Logical operators `and` | `or` cut off varargs, this is especially annoying when working with recursive functions (Lua has TCO).
+* You can't easely store varargs for later. You can create closures or pack varargs into tables to do these things,
+but then you have to worry about escaping the nil values, which are valid in varargs but signal the end of tables, like `\0` in C strings.
 
 ```lua
->2+2
-  stdin:1: unexpected symbol near '2'
->return 2+2
-  4
+local as_closure = function(...) return ... end -- function variant -- expensive ?
+local as_table   = {n = select('#',...),...} -- table variant -- n field to indicate the last vararg index
 ```
+
+* Table indexes start at one in array literals, and in the standard library.
+You can use 0-based indexing, but then you can't use either of those things.
 
 * Lua's default string library provides only a subset of regular expressions, that is itself incompatible with the usual PCRE regexes.
 * No default way to copy a table. You can write a function for that which will work till you'll want to copy a table with `__index` metamethod.
@@ -55,3 +76,8 @@ assigned a metatable and string values called with methods. The same is not true
 >(3.14):floor()
   stdin:1: attempt to index a number value
 ```
+
+# Toolchain
+
+* Lua doesn't have an offical toolchain as its an embedable language
+* LuaRocks exists but is too hard to setup, especially on Windows


### PR DESCRIPTION
Added Categories
The global environement being a table, means you can give it a metatable and overload its indexing and assignement operations to avoid globals altogheter
Iterating over varargs is possible trough `select` and getting their amount is aswell possible by suppling "#" as `select`'s first argument
This also means you know the size of the table when you pack varags `{...}`
Storing varargs for later can be possible using closures, altough creating function's isn't free, a table would be better (with a size field somewhere from `select('#',...)`)
while doesn't need parenthesis in its syntax
Moved the `continue` complain into Syntax category
Lua doesn't have a toolchain, its meant for embedding but LuaRocks is worth a mention